### PR TITLE
Vite v3 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint --fix --ext .js,.ts,.vue ./"
   },
   "peerDependencies": {
-    "vite": "^2.0.0"
+    "vite": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.6.2",


### PR DESCRIPTION
The package is working seamlessly with Vite v3, so I added the version in the peer dependencies to allow package managers to install it.