### PR TITLE
feat: support functions to compute exported value

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,25 +73,6 @@ modules['virtual:config'] = { hello: 'new message' }
 invalidateVirtualModule(server, 'virtual:config')
 ```
 
-## Modifying the plugin
-
-If you are using this plugin to simplify building your own plugin, you may want to change the plugin name, and some other config.
-
-```js
-import type { Plugin } from 'vite'
-import virtual from 'vite-plugin-virtual'
-
-export function virtualPlugin(): Plugin {
-  return {
-    ...(virtual as any).default({
-      'virtual:your-plugin': 'export const hello = "world"',
-    }),
-    name: 'your-plugin:virtual',
-    enforce: 'post', // You can modify the plugin here.
-  }
-}
-```
-
 ## Credits
 
 - Adapted logic from [@rollup/plugin-virtual](https://github.com/rollup/plugins/tree/master/packages/virtual)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ import virtual, { updateVirtualModule } from 'vite-plugin-virtual'
 const plugin = virtual({
   'virtual:module': `export default { hello: 'world' }`,
   'virtual:config': { hello: 'world' },
-  'virtual:something-else': () => return `Hello ${'computed'} world`,
+  'virtual:lazy': () => `Hello ${'computed'} world`,
 })
 
 updateVirtualModule( plugin, 'virtual:config', { hello: 'new message' } )

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ import virtual, { updateVirtualModule } from 'vite-plugin-virtual'
 
 const plugin = virtual({
   'virtual:module': `export default { hello: 'world' }`,
-  'virtual:config': { hello: 'world' }
+  'virtual:config': { hello: 'world' },
+  'virtual:something-else': () => return `Hello ${'computed'} world`,
 })
 
 updateVirtualModule( plugin, 'virtual:config', { hello: 'new message' } )
@@ -72,10 +73,29 @@ modules['virtual:config'] = { hello: 'new message' }
 invalidateVirtualModule(server, 'virtual:config')
 ```
 
+## Modifying the plugin
+
+If you are using this plugin to simplify building your own plugin, you may want to change the plugin name, and some other config.
+
+```js
+import type { Plugin } from 'vite'
+import virtual from 'vite-plugin-virtual'
+
+export function virtualPlugin(): Plugin {
+  return {
+    ...(virtual as any).default({
+      'virtual:your-plugin': 'export const hello = "world"',
+    }),
+    name: 'your-plugin:virtual',
+    enforce: 'post', // You can modify the plugin here.
+  }
+}
+```
+
 ## Credits
 
 - Adapted logic from [@rollup/plugin-virtual](https://github.com/rollup/plugins/tree/master/packages/virtual)
-- Project setup adopted from [@antfu's Vite plugins](https://github.com/antfu/vite-plugin-pwa) 
+- Project setup adopted from [@antfu's Vite plugins](https://github.com/antfu/vite-plugin-pwa)
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import path from 'path'
-import type { Plugin, ViteDevServer, ModuleNode } from 'vite'
+import type { Plugin, ViteDevServer } from 'vite'
 
-export type VirtualModule = string | object
+export type VirtualModule = string | object | (() => string | object)
 
 export interface VirtualModules {
   [id: string]: VirtualModule
@@ -66,7 +66,8 @@ function virtual(modules: VirtualModules = {}): Plugin {
         const idNoPrefix = id.slice(VIRTUAL_PREFIX.length)
         const resolvedId = idNoPrefix in modules ? idNoPrefix : resolvedIds.get(idNoPrefix)
         if (resolvedId) {
-          const module = modules[resolvedId]
+          let module = modules[resolvedId]
+          module = typeof module === 'function' ? module() : module
           return typeof module === 'string' ? module : `export default ${JSON.stringify(module)}`
         }
       }


### PR DESCRIPTION
Sometimes, you don't know the value until some other calculation has been done. In this case, evaluating the function when the virtual module is loaded solves the problem.

My usecase:

I use vite-plugin-virtual to simplify serving virtual files in one of my plugins. I have something like this:

```js
export function myPlugin() {
	const ctx = { a = 0; }
	return [
		findAndModifyContextPlugin(ctx)
		{
			...virtual({
				"my-plugin": () => ctx.a
			}),
			name: "my-plugin:virtual",
			enfore: "post",
		},
	]
}
```

Right now, since I cannot use vite-plugin-virtual with functions, `ctx.a` is evaluated directly, and always results in `0`.