### PR TITLE
chore: Vite 6 in peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint": "eslint ."
   },
   "peerDependencies": {
-    "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
+    "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^2.6.4",


### PR DESCRIPTION
fix #11 

I modeled this commit after 8253c82469e1cb6ac7c6c5ab70a7e7e77ccf3310